### PR TITLE
refactor: thingie slot

### DIFF
--- a/packages/be/modules/thingie/model/index.js
+++ b/packages/be/modules/thingie/model/index.js
@@ -44,6 +44,11 @@ const ThingieSchema = new Schema({
   angle: {
     type: Number,
     required: true
+  },
+  media: {
+    type: String,
+    required: true,
+    enum: ['image', 'text', 'sound', 'video']
   }
 }, {
   timestamps: true,

--- a/packages/be/modules/thingie/model/index.js
+++ b/packages/be/modules/thingie/model/index.js
@@ -54,6 +54,14 @@ const ThingieSchema = new Schema({
     type: String,
     required: false
   },
+  fontsize: {
+    type: Number,
+    required: false
+  },
+  fontfamily: {
+    type: String,
+    required: false
+  },
   creator_token: {
     type: String,
     required: true

--- a/packages/be/modules/thingie/model/index.js
+++ b/packages/be/modules/thingie/model/index.js
@@ -11,12 +11,12 @@ const ThingieSchema = new Schema({
   file_ref: {
     type: Schema.Types.ObjectId,
     ref: 'uploads',
-    required: true
+    required: false
   },
   location: {
     type: String,
     required: true,
-    enum: ['space', 'pocket', 'compost']
+    enum: ['spaze', 'pocket', 'compost']
   },
   dragging: {
     type: Boolean,
@@ -45,10 +45,18 @@ const ThingieSchema = new Schema({
     type: Number,
     required: true
   },
-  media: {
+  thingie_type: {
     type: String,
     required: true,
     enum: ['image', 'text', 'sound', 'video']
+  },
+  text: {
+    type: String,
+    required: false
+  },
+  creator_token: {
+    type: String,
+    required: true
   }
 }, {
   timestamps: true,

--- a/packages/be/modules/thingie/model/index.js
+++ b/packages/be/modules/thingie/model/index.js
@@ -36,6 +36,14 @@ const ThingieSchema = new Schema({
       type: Number,
       required: true
     }
+  },
+  width: {
+    type: Number,
+    required: true
+  },
+  angle: {
+    type: Number,
+    required: true
   }
 }, {
   timestamps: true,

--- a/packages/be/modules/thingie/rest/post-create-thingy.js
+++ b/packages/be/modules/thingie/rest/post-create-thingy.js
@@ -22,7 +22,9 @@ MC.app.post('/post-create-thingie', async (req, res) => {
         x: Math.random() * 300,
         y: Math.random() * 300,
         z: Math.random() * 300
-      }
+      },
+      width: 80,
+      angle: 0
     })
     await created.populate({
       path: 'file_ref',

--- a/packages/be/modules/thingie/rest/post-create-thingy.js
+++ b/packages/be/modules/thingie/rest/post-create-thingy.js
@@ -19,9 +19,9 @@ MC.app.post('/post-create-thingie', async (req, res) => {
       file_ref: body.file_id,
       location: body.location,
       at: {
-        x: Math.random() * 300,
-        y: Math.random() * 300,
-        z: Math.random() * 300
+        x: body.at ? body.at.x : Math.random() * 300,
+        y: body.at ? body.at.y : Math.random() * 300,
+        z: 1
       },
       width: 80,
       angle: 0,

--- a/packages/be/modules/thingie/rest/post-create-thingy.js
+++ b/packages/be/modules/thingie/rest/post-create-thingy.js
@@ -12,19 +12,22 @@ MC.app.post('/post-create-thingie', async (req, res) => {
   try {
     const body = req.body
     const upload = await MC.model.Upload.findById(body.file_id)
-    if (!upload) {
+    if (!upload && body.thingie_type !== 'text') {
       throw new Error('File could not be uploaded. Please try again.')
     }
     const created = await MC.model.Thingie.create({
       file_ref: body.file_id,
-      location: 'pocket',
+      location: body.location,
       at: {
         x: Math.random() * 300,
         y: Math.random() * 300,
         z: Math.random() * 300
       },
       width: 80,
-      angle: 0
+      angle: 0,
+      creator_token: body.creator_token,
+      thingie_type: body.thingie_type,
+      text: body.text
     })
     await created.populate({
       path: 'file_ref',

--- a/packages/be/modules/thingie/rest/post-delete-thingy.js
+++ b/packages/be/modules/thingie/rest/post-delete-thingy.js
@@ -17,23 +17,34 @@ MC.app.post('/post-delete-thingie', async (req, res) => {
   try {
     const thingieId = req.body.thingie_id
     const thingie = await MC.model.Thingie.findById(thingieId)
-    const fileId = thingie.file_ref
-    const upload = await MC.model.Upload.findById(fileId)
-    const fileExt = upload.file_ext
-    if (!thingie || !upload) {
+    if (!thingie) {
       throw new Error('File does not exist!')
     }
-    const deletedUpload = await MC.model.Upload.deleteOne(upload)
-    const deletedThingie = await MC.model.Thingie.deleteOne(thingie)
-    Fs.unlink(`${UPLOADS_DIR}/${fileId}.${fileExt}`, (err) => {
-      if (err) {
-        console.log(err)
-      } else {
-        console.log(`deleted ${fileId}.${fileExt}`)
+    if (thingie.thingie_type !== 'text') {
+      const fileId = thingie.file_ref
+      const upload = await MC.model.Upload.findById(fileId)
+      const fileExt = upload.file_ext
+      if (!upload) {
+        throw new Error('File does not exist!')
       }
-    })
+      const deletedUpload = await MC.model.Upload.deleteOne(upload)
+      const deletedThingie = await MC.model.Thingie.deleteOne(thingie)
+      console.log(deletedUpload)
+      console.log(deletedThingie)
+      Fs.unlink(`${UPLOADS_DIR}/${fileId}.${fileExt}`, (err) => {
+        if (err) {
+          console.log(err)
+        } else {
+          console.log(`deleted ${fileId}.${fileExt}`)
+        }
+      })
+    } else {
+      const deletedTextThingie = await MC.model.Thingie.deleteOne(thingie)
+      console.log(deletedTextThingie)
+    }
+    console.log(`deleted file ${thingieId}`)
     MC.socket.io.to('thingies').emit('module|post-delete-thingie|payload', thingieId)
-    SendData(res, 200, 'Thingie successfully deleted', `deleted file ${fileId}.${fileExt}`)
+    SendData(res, 200, 'Thingie successfully deleted', 'deleted thingie')
   } catch (e) {
     console.log('================== [Endpoint: /post-delete-thingie]')
     console.log(e)

--- a/packages/fe/assets/scss/main.scss
+++ b/packages/fe/assets/scss/main.scss
@@ -515,6 +515,8 @@ h6, .h6 {
   position: absolute;
   width: 80px;
   cursor: grab;
+  transform-origin: center;
+  transition: width 100ms linear, transform 100ms linear;
   &.image,
   &.text,
   &.sound,

--- a/packages/fe/assets/scss/main.scss
+++ b/packages/fe/assets/scss/main.scss
@@ -510,27 +510,3 @@ h6, .h6 {
     @include linkShadow;
   }
 }
-
-.thingie {
-  position: absolute;
-  width: 80px;
-  cursor: grab;
-  transform-origin: center;
-  transition: all 50ms linear;
-  &.image,
-  &.text,
-  &.sound,
-  &.video {
-    position: absolute;
-  }
-  &:active {
-    cursor: grabbing;
-  }
-  img {
-    width: 100%;
-    pointer-events: none;
-  }
-  &.locked {
-    pointer-events: none;
-  }
-}

--- a/packages/fe/assets/scss/main.scss
+++ b/packages/fe/assets/scss/main.scss
@@ -516,7 +516,7 @@ h6, .h6 {
   width: 80px;
   cursor: grab;
   transform-origin: center;
-  transition: width 100ms linear, transform 100ms linear;
+  transition: all 50ms linear;
   &.image,
   &.text,
   &.sound,

--- a/packages/fe/assets/scss/main.scss
+++ b/packages/fe/assets/scss/main.scss
@@ -279,17 +279,24 @@ span.error {
 
 ////////////////////////////////////////////////////////////////////////// Fonts
 //------------------------------------------------------------------------------
-// Font Sizing
-// 10px = 0.625rem
-// 12px = 0.75rem
-// 14px = 0.875rem
-// 16px = 1rem (base)
-// 18px = 1.125rem
-// 19px = 1.1875rem
-// 20px = 1.25rem
-// 24px = 1.5rem
-// 30px = 1.875rem
-// 32px = 2rem
+.anton {
+  @include fontFamily_Anton;
+}
+.arvo {
+  @include fontFamily_Arvo;
+}
+.courier {
+  @include fontFamily_CourierPrime;
+}
+.merriweather {
+  @include fontFamily_Merriweather;
+}
+.nanum {
+  @include fontFamily_NanumMyeongjo;
+}
+.source-code {
+  @include fontFamily_SourceCodePro;
+}
 
 h1, .h1,
 h2, .h2,

--- a/packages/fe/assets/scss/typography.scss
+++ b/packages/fe/assets/scss/typography.scss
@@ -13,6 +13,7 @@
 
 @mixin fontSize_teeny { font-size: 0.6875rem; } // fontSize_teeny | 11pt
 @mixin fontSize_Main { font-size: 0.8125rem; } // fontSize_Main | 13pt
+@mixin fontSize_Bigger { font-size: 1rem; } // fontSize_Bigger | 16pt
 
 @mixin fontWeight_Regular { font-weight: 400; }
 @mixin fontWeight_Medium { font-weight: 500; }

--- a/packages/fe/assets/scss/variables.scss
+++ b/packages/fe/assets/scss/variables.scss
@@ -67,7 +67,7 @@ $breakpoint_UltraLarge: 140.625rem; // 2250px
 }
 
 @mixin focusBoxShadowSmall {
-  box-shadow: 0 0 0 3px rgba(0, 123, 255, 0.5);
+  box-shadow: 0 0 3px 3px rgba(203, 192, 217, 0.5);
 }
 
 @mixin focusBoxShadowLink {

--- a/packages/fe/components/bingo.vue
+++ b/packages/fe/components/bingo.vue
@@ -14,6 +14,9 @@
 </template>
 
 <script>
+// ====================================================================== Import
+import { mapGetters } from 'vuex'
+
 // ====================================================================== Export
 export default {
   name: 'Bingo',
@@ -38,14 +41,6 @@ export default {
 
   data () {
     return {
-      fonts: [
-        'anton',
-        'arvo',
-        'courier',
-        'merriweather',
-        'nanum',
-        'source-code'
-      ],
       defaults: {
         lsx: 50, // horizontal Letter spacing
         lsy: 30, // vertical Letter spacing
@@ -59,6 +54,12 @@ export default {
   },
 
   computed: {
+    ...mapGetters({
+      landing: 'general/landing'
+    }),
+    fonts () {
+      return this.landing.data.font_families
+    },
     letters () {
       return this.text.split('')
     },

--- a/packages/fe/components/landing-site.vue
+++ b/packages/fe/components/landing-site.vue
@@ -28,12 +28,15 @@
       <template v-if="authenticated && isNotLandingPage">
         <div :class="['tips', { tipsOpen }]">
           <ul>
-            <li
-              v-for="tip in tips"
-              :key="tip"
-              class="tip">
-              {{ tip }}
-            </li>
+            <template v-for="tip in tips">
+              <li
+                v-if="tip !== 'br'"
+                :key="tip"
+                class="tip">
+                {{ tip }}
+              </li>
+              <br v-else>
+            </template>
           </ul>
         </div>
       </template>
@@ -194,6 +197,7 @@ export default {
 .tip {
   position: relative;
   list-style-type: none;
+  @include fontSize_Main;
   &:before {
     content: '';
     position: absolute;

--- a/packages/fe/components/prop-board.vue
+++ b/packages/fe/components/prop-board.vue
@@ -72,7 +72,12 @@ export default {
       const complete = await this.postCreateThingie({
         location: 'spaze',
         text: this.text,
-        type: 'text'
+        type: 'text',
+        at: {
+          x: this.location.x,
+          y: this.location.y,
+          z: 1
+        }
       })
       if (complete) {
         this.status = 'upload-finalized'

--- a/packages/fe/components/prop-board.vue
+++ b/packages/fe/components/prop-board.vue
@@ -2,7 +2,7 @@
   <div
     :class="['prop-board', { open }]"
     :style="editorStyles">
-    <form action="">
+    <form action="" class="text-form">
 
       <div class="text-area-wrapper">
         <textarea v-model="text" class="text-input" />
@@ -10,8 +10,9 @@
 
       <button
         type="submit"
+        class="add-button"
         @click.prevent="createTextThingie">
-        submit
+        add
       </button>
 
     </form>
@@ -92,10 +93,42 @@ export default {
 // ///////////////////////////////////////////////////////////////////// General
 .prop-board {
   position: absolute;
-  border: 1px solid black;
+  padding: 0.25rem;
+  width: 20rem;
+  height: 8rem;
+  @include focusBoxShadowSmall;
+  border-radius: 0.25rem;
+  background-color: #ffffff;
   visibility: hidden;
+  @include popOutAnimation;
+  z-index: 100000;
   &.open {
     visibility: visible;
+    @include popInAnimation;
   }
+}
+
+.text-form {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.text-area-wrapper {
+  flex-grow: 1;
+  width: 100%;
+}
+
+.text-input {
+  width: 100%;
+  height: 100%;
+}
+
+.add-button {
+  width: fit-content;
+  align-self: flex-end;
+  margin-right: 0.5rem;
+  @include linkHover(#000000);
 }
 </style>

--- a/packages/fe/components/prop-board.vue
+++ b/packages/fe/components/prop-board.vue
@@ -1,0 +1,96 @@
+<template>
+  <div
+    :class="['prop-board', { open }]"
+    :style="editorStyles">
+    <form action="">
+
+      <div class="text-area-wrapper">
+        <textarea v-model="text" class="text-input" />
+      </div>
+
+      <button
+        type="submit"
+        @click.prevent="createTextThingie">
+        submit
+      </button>
+
+    </form>
+  </div>
+</template>
+
+<script>
+// ====================================================================== Import
+import { mapActions } from 'vuex'
+
+// ====================================================================== Export
+export default {
+  name: 'PropBoard',
+
+  props: {
+    location: {
+      type: Object,
+      required: true,
+      default: () => ({
+        x: 0,
+        y: 0
+      })
+    }
+  },
+
+  data () {
+    return {
+      open: false,
+      text: '',
+      status: false
+    }
+  },
+
+  computed: {
+    editorStyles () {
+      return {
+        left: this.location.x + 'px',
+        top: this.location.y + 'px'
+      }
+    }
+  },
+
+  methods: {
+    ...mapActions({
+      postCreateThingie: 'collections/postCreateThingie'
+    }),
+    openEditor () {
+      if (!this.open) {
+        this.open = true
+      }
+    },
+    closeEditor () {
+      if (this.open) {
+        this.open = false
+      }
+    },
+    async createTextThingie () {
+      const complete = await this.postCreateThingie({
+        location: 'spaze',
+        text: this.text,
+        type: 'text'
+      })
+      if (complete) {
+        this.status = 'upload-finalized'
+        this.closeEditor()
+      }
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+// ///////////////////////////////////////////////////////////////////// General
+.prop-board {
+  position: absolute;
+  border: 1px solid black;
+  visibility: hidden;
+  &.open {
+    visibility: visible;
+  }
+}
+</style>

--- a/packages/fe/components/single-file-uploader.vue
+++ b/packages/fe/components/single-file-uploader.vue
@@ -137,7 +137,9 @@ export default {
     },
     async finalizeUpload () {
       const complete = await this.postCreateThingie({
-        uploadedFileId: this.file.id
+        uploadedFileId: this.file.id,
+        location: 'pocket',
+        type: 'image'
       })
       if (complete) {
         this.status = 'upload-finalized'

--- a/packages/fe/components/thingie.vue
+++ b/packages/fe/components/thingie.vue
@@ -24,11 +24,19 @@ export default {
     position () {
       return this.thingie.at
     },
+    scale () {
+      return this.thingie.width ? this.thingie.width : 80
+    },
+    rotate () {
+      return this.thingie.angle
+    },
     styles () {
       return {
         left: this.position.x + 'px',
         top: this.position.y + 'px',
-        zIndex: this.position.z + 'px'
+        zIndex: this.position.z + 'px',
+        width: this.scale + 'px',
+        transform: `rotate(${this.rotate}deg)`
       }
     }
   },
@@ -85,6 +93,16 @@ export default {
       evt.dataTransfer.effectAllowed = 'move'
       evt.dataTransfer.setData('_id', this.thingie._id)
     }
+    // wheel (evt) {
+    //   evt.preventDefault();
+    //   if (evt.ctrlKey && this.scale) {
+    //     const coef = this.scale - evt.deltaY * 0.01
+    //     this.$emit('wheel', {
+    //       _id: this.thingie._id,
+    //       scale: coef
+    //     })
+    //   }
+    // }
   },
 
   render () {

--- a/packages/fe/components/thingie.vue
+++ b/packages/fe/components/thingie.vue
@@ -1,8 +1,7 @@
 <template>
   <div
-    :thingie="thingie"
     draggable
-    :class="['thingie', { locked: !authenticated }]"
+    :class="['thingie', `${type}-thingie`, { locked: !authenticated }]"
     :style="styles"
     @mousedown="mousedown($event)"
     @dragstart="startDrag($event)"
@@ -36,6 +35,12 @@ export default {
   },
 
   computed: {
+    ...mapGetters({
+      authenticated: 'general/authenticated'
+    }),
+    type () {
+      return this.thingie.thingie_type
+    },
     position () {
       return this.thingie.at
     },
@@ -52,14 +57,14 @@ export default {
         zIndex: this.position.z + 'px',
         width: this.scale + 'px',
         transform: `rotate(${this.rotate}deg)`
+        // '--relative-font-size': `${this.scale * 13 / 80}px`
       }
     }
   },
 
   methods: {
     ...mapActions({
-      updateThingie: 'collections/updateThingie',
-      authenticated: 'general/authenticated'
+      updateThingie: 'collections/updateThingie'
     }),
     mousedown (evt) {
       if (this.authenticated) {
@@ -113,31 +118,34 @@ export default {
         evt.dataTransfer.dropEffect = 'move'
         evt.dataTransfer.effectAllowed = 'move'
         evt.dataTransfer.setData('_id', this.thingie._id)
+        console.log('hit')
       }
     },
     wheel (evt) {
-      evt.preventDefault();
-      if (evt.ctrlKey) {
-        if (evt.altKey) {
-          const angle = !Number.isNaN(this.thingie.angle) ? this.thingie.angle : 0
-          const newAngle = angle - evt.deltaY
-          this.$emit('initupdate', {
-            _id: this.thingie._id,
-            angle: newAngle
-          })
-        } else {
-          const width = this.thingie.width ? this.thingie.width : 80
-          const newWidth = Math.max(width - evt.deltaY, 1)
-          const delta = (width - newWidth) / 2
-          this.$emit('initupdate', {
-            _id: this.thingie._id,
-            width: newWidth,
-            at: {
-              x: this.thingie.at.x + delta,
-              y: this.thingie.at.y + delta,
-              z: this.thingie.at.z
-            }
-          })
+      if (this.authenticated) {
+        evt.preventDefault();
+        if (evt.ctrlKey) {
+          if (evt.altKey) {
+            const angle = !Number.isNaN(this.thingie.angle) ? this.thingie.angle : 0
+            const newAngle = angle - evt.deltaY
+            this.$emit('initupdate', {
+              _id: this.thingie._id,
+              angle: newAngle
+            })
+          } else {
+            const width = this.thingie.width ? this.thingie.width : 80
+            const newWidth = Math.max(width - evt.deltaY, 1)
+            const delta = (width - newWidth) / 2
+            this.$emit('initupdate', {
+              _id: this.thingie._id,
+              width: newWidth,
+              at: {
+                x: this.thingie.at.x + delta,
+                y: this.thingie.at.y + delta,
+                z: this.thingie.at.z
+              }
+            })
+          }
         }
       }
     }
@@ -161,12 +169,11 @@ export default {
   width: 80px;
   cursor: grab;
   transform-origin: center;
-  transition: all 50ms linear;
-  &.image,
-  &.text,
-  &.sound,
-  &.video {
-    position: absolute;
+  // transition: all 100ms linear;
+  &.image-thingie,
+  &.text-thingie,
+  &.sound-thingie,
+  &.video-thingie {
   }
   &:active {
     cursor: grabbing;
@@ -177,6 +184,18 @@ export default {
   }
   &.locked {
     pointer-events: none;
+  }
+}
+
+.thingie.text-thingie {
+  // --relative-font-size: 13px;
+  ::v-deep .text-feel {
+    position: relative;
+    width: fit-content;
+    margin: auto;
+    z-index: 0;
+    pointer-events: none;
+    // font-size: var(--relative-font-size);
   }
 }
 </style>

--- a/packages/fe/data/landing.json
+++ b/packages/fe/data/landing.json
@@ -58,7 +58,10 @@
       "to upload a thingie, open the pocket and click upload",
       "to move a thingie, click and drag it",
       "to move a thingie between spaces, hold shift while dragging to drag and drop",
-      "to get rid of a thingie, drag and drop it into the open trash"
+      "to get rid of a thingie, drag and drop it into the open trash",
+      "br",
+      "to shrink or enlarge a thingie, hover over it with two finger and make a pinching gesture",
+      "to rotate a thingie, do the above while holding down the option key"
     ]
   }
 }

--- a/packages/fe/data/landing.json
+++ b/packages/fe/data/landing.json
@@ -63,5 +63,13 @@
       "to shrink or enlarge a thingie, hover over it with two finger and make a pinching gesture",
       "to rotate a thingie, do the above while holding down the option key"
     ]
-  }
+  },
+  "font_families": [
+    "nanum",
+    "courier",
+    "merriweather",
+    "source-code",
+    "anton",
+    "arvo"
+  ]
 }

--- a/packages/fe/data/landing.json
+++ b/packages/fe/data/landing.json
@@ -61,7 +61,10 @@
       "to get rid of a thingie, drag and drop it into the open trash",
       "br",
       "to shrink or enlarge a thingie, hover over it with two finger and make a pinching gesture",
-      "to rotate a thingie, do the above while holding down the option key"
+      "to rotate a thingie, do the above while holding down the option key",
+      "br",
+      "to add a text thingie, hold option and click anywhere on the white space",
+      "to change font size and family, hold command and click on the text"
     ]
   },
   "font_families": [

--- a/packages/fe/modules/compost/components/compost-portal.vue
+++ b/packages/fe/modules/compost/components/compost-portal.vue
@@ -65,7 +65,6 @@ export default {
       removeThingie: 'collections/removeThingie'
     }),
     onCompost (evt) {
-      console.log(evt)
       evt.preventDefault()
       const thingieId = evt.dataTransfer.getData('_id')
       this.deleteThingie (thingieId)

--- a/packages/fe/modules/pocket/components/pocket.vue
+++ b/packages/fe/modules/pocket/components/pocket.vue
@@ -23,17 +23,10 @@
 
           <Thingie
             :thingie="thingie"
-            @drag="initDrag">
-            <div
-              slot-scope="{ mousedown, mouseup, startDrag, styles }"
-              draggable
-              class="thingie"
-              :style="styles"
-              @mousedown="initMousedown($event, mousedown, thingie)"
-              @mouseup="initMouseup($event, mouseup, thingie)"
-              @dragstart="startDrag($event)">
-              <img :src="`${$config.backendUrl}/${thingie.file_ref._id}.${thingie.file_ref.file_ext}`" />
-            </div>
+            @initmousedown="initMousedown"
+            @initupdate="initUpdate"
+            @initmouseup="initMouseup">
+            <img :src="`${$config.backendUrl}/${thingie.file_ref._id}.${thingie.file_ref.file_ext}`" />
           </Thingie>
 
         </template>
@@ -101,44 +94,35 @@ export default {
       updateThingie: 'collections/updateThingie',
       addThingie: 'collections/addThingie'
     }),
-    initMousedown (evt, mousedown, thingie) {
-      console.log('initMousedown')
-      mousedown(evt)
+    initMousedown (thingie) {
       this.socket.emit('update-thingie', {
         _id: thingie._id,
         dragging: true
       })
     },
-    initMouseup (evt, mouseup, thingie) {
-      console.log('initMouseup')
-      mouseup(evt)
+    initMouseup (thingie) {
       this.socket.emit('update-thingie', {
         _id: thingie._id,
         dragging: false
       })
     },
-    initDrag (thingie) {
-      console.log('initDrag')
-      this.socket.emit('update-thingie', {
-        _id: thingie._id,
-        at: thingie.at
-      })
+    initUpdate (thingie) {
+      this.socket.emit('update-thingie', thingie)
     },
     onDrop (evt) {
-      console.log('onDrop — pocket')
-      evt.preventDefault()
-
-      const rect = evt.target.getBoundingClientRect()
-      const x = Math.max(0, Math.min(640, evt.clientX - rect.left))
-      const y = Math.max(0, Math.min(400, evt.clientY - rect.top))
-
-      const thingieId = evt.dataTransfer.getData('_id')
-      this.socket.emit('update-thingie', {
-        _id: thingieId,
-        location: 'pocket',
-        dragging: false,
-        at: { x, y, z: 1 }
-      })
+      if (this.authenticated) {
+        evt.preventDefault()
+        const rect = evt.target.getBoundingClientRect()
+        const x = Math.max(0, Math.min(640, evt.clientX - rect.left))
+        const y = Math.max(0, Math.min(400, evt.clientY - rect.top))
+        const thingieId = evt.dataTransfer.getData('_id')
+        this.socket.emit('update-thingie', {
+          _id: thingieId,
+          location: 'pocket',
+          dragging: false,
+          at: { x, y, z: 1 }
+        })
+      }
     }
   }
 }

--- a/packages/fe/modules/pocket/components/pocket.vue
+++ b/packages/fe/modules/pocket/components/pocket.vue
@@ -26,7 +26,17 @@
             @initmousedown="initMousedown"
             @initupdate="initUpdate"
             @initmouseup="initMouseup">
-            <img :src="`${$config.backendUrl}/${thingie.file_ref._id}.${thingie.file_ref.file_ext}`" />
+
+            <template v-if="thingie.thingie_type === 'text'">
+              <div class="text-feel">
+                {{ thingie.text }}
+              </div>
+            </template>
+
+            <template v-else>
+              <img :src="`${$config.backendUrl}/${thingie.file_ref._id}.${thingie.file_ref.file_ext}`" />
+            </template>
+            
           </Thingie>
 
         </template>

--- a/packages/fe/modules/pocket/store/index.js
+++ b/packages/fe/modules/pocket/store/index.js
@@ -16,9 +16,8 @@ const getters = {
 // -----------------------------------------------------------------------------
 const actions = {
   // ////////////////////////////////////////////////////// setPocketConsistency
-  setPocketConsistency ({ commit }) {
-    string = ''
-    commit('SET_POCKET_CONSISTENCY', string)
+  setPocketToken ({ commit }, token) {
+    commit('SET_POCKET_TOKEN', token)
   },
   // /////////////////////////////////////////////////////////// setPocketIsOpen
   setPocketIsOpen ({ commit }, val) {
@@ -29,7 +28,7 @@ const actions = {
 // /////////////////////////////////////////////////////////////////// Mutations
 // -----------------------------------------------------------------------------
 const mutations = {
-  SET_POCKET_CONSISTENCY (state, incoming) {
+  SET_POCKET_TOKEN (state, incoming) {
     state.pocket = incoming
   },
   SET_POCKET_IS_OPEN (state, val) {

--- a/packages/fe/pages/index.vue
+++ b/packages/fe/pages/index.vue
@@ -68,6 +68,10 @@ export default {
     Scatter
   },
 
+  async fetch ({ app, store }) {
+    await store.dispatch('general/setLandingData')
+  },
+
   data () {
     return {
       irridescent: {

--- a/packages/fe/pages/info.vue
+++ b/packages/fe/pages/info.vue
@@ -80,6 +80,10 @@ export default {
     Shader
   },
 
+  async fetch ({ app, store }) {
+    await store.dispatch('general/setLandingData')
+  },
+
   data () {
     return {
       mew: {

--- a/packages/fe/pages/portal.vue
+++ b/packages/fe/pages/portal.vue
@@ -56,6 +56,7 @@ export default {
   },
 
   async fetch ({ app, store }) {
+    await store.dispatch('general/setLandingData')
     await store.dispatch('collections/getThingies')
   },
 

--- a/packages/fe/pages/portal.vue
+++ b/packages/fe/pages/portal.vue
@@ -9,7 +9,8 @@
 
       <Thingie
         :thingie="thingie"
-        @drag="initDrag">
+        @drag="initDrag"
+        @wheel.native="initWheel($event, thingie)">
         <div
           slot-scope="{ mousedown, mouseup, startDrag, wheel, styles }"
           draggable
@@ -17,8 +18,7 @@
           :style="styles"
           @mousedown="initMousedown($event, mousedown, thingie)"
           @mouseup="initMouseup($event, mouseup, thingie)"
-          @dragstart="startDrag($event)"
-          @wheel="initWheel($event, thingie)">
+          @dragstart="startDrag($event)">
           <img :src="`${$config.backendUrl}/${thingie.file_ref._id}.${thingie.file_ref.file_ext}`" />
         </div>
       </Thingie>
@@ -108,7 +108,6 @@ export default {
     },
     initWheel (evt, thingie) {
       evt.preventDefault();
-      console.log(evt)
       if (evt.ctrlKey) {
         if (evt.altKey) {
           const angle = !Number.isNaN(thingie.angle) ? thingie.angle : 0
@@ -120,9 +119,15 @@ export default {
         } else {
           const width = thingie.width ? thingie.width : 80
           const newWidth = Math.max(width - evt.deltaY, 1)
+          const delta = (width - newWidth) / 2
           this.socket.emit('update-thingie', {
             _id: thingie._id,
-            width: newWidth
+            width: newWidth,
+            at: {
+              x: thingie.at.x + delta,
+              y: thingie.at.y + delta,
+              z: thingie.at.z
+            }
           })
         }
       }

--- a/packages/fe/pages/portal.vue
+++ b/packages/fe/pages/portal.vue
@@ -11,13 +11,14 @@
         :thingie="thingie"
         @drag="initDrag">
         <div
-          slot-scope="{ mousedown, mouseup, startDrag, styles }"
+          slot-scope="{ mousedown, mouseup, startDrag, wheel, styles }"
           draggable
           :class="['thingie', { locked: !authenticated }]"
           :style="styles"
           @mousedown="initMousedown($event, mousedown, thingie)"
           @mouseup="initMouseup($event, mouseup, thingie)"
-          @dragstart="startDrag($event)">
+          @dragstart="startDrag($event)"
+          @wheel="initWheel($event, thingie)">
           <img :src="`${$config.backendUrl}/${thingie.file_ref._id}.${thingie.file_ref.file_ext}`" />
         </div>
       </Thingie>
@@ -104,6 +105,27 @@ export default {
         _id: thingie._id,
         at: thingie.at
       })
+    },
+    initWheel (evt, thingie) {
+      evt.preventDefault();
+      console.log(evt)
+      if (evt.ctrlKey) {
+        if (evt.altKey) {
+          const angle = !Number.isNaN(thingie.angle) ? thingie.angle : 0
+          const newAngle = angle - evt.deltaY
+          this.socket.emit('update-thingie', {
+            _id: thingie._id,
+            angle: newAngle
+          })
+        } else {
+          const width = thingie.width ? thingie.width : 80
+          const newWidth = Math.max(width - evt.deltaY, 1)
+          this.socket.emit('update-thingie', {
+            _id: thingie._id,
+            width: newWidth
+          })
+        }
+      }
     },
     onDrop (evt) {
       if (this.authenticated) {

--- a/packages/fe/pages/portal.vue
+++ b/packages/fe/pages/portal.vue
@@ -7,14 +7,10 @@
     @click.alt.self="openEditor($event)"
     @click.self="closeEditor($event)">
 
-    <div
-      :class="['editor', { open: editor.open }]"
-      :style="{ left: editor.left + 'px', top: editor.top + 'px' }">
-      <form>
-        <textarea />
-        <input type="submit" />
-      </form>
-    </div>
+    <PropBoard
+      v-if="authenticated"
+      ref="propboard"
+      :location="editor" />
 
     <template v-for="thingie in spazeThingies">
 
@@ -23,7 +19,17 @@
         @initmousedown="initMousedown"
         @initupdate="initUpdate"
         @initmouseup="initMouseup">
-        <img :src="`${$config.backendUrl}/${thingie.file_ref._id}.${thingie.file_ref.file_ext}`" />
+
+        <template v-if="thingie.thingie_type === 'text'">
+          <div class="text-feel">
+            {{ thingie.text }}
+          </div>
+        </template>
+
+        <template v-else>
+          <img :src="`${$config.backendUrl}/${thingie.file_ref._id}.${thingie.file_ref.file_ext}`" />
+        </template>
+
       </Thingie>
 
     </template>
@@ -36,6 +42,7 @@
 import { mapGetters, mapActions } from 'vuex'
 
 import Thingie from '@/components/thingie'
+import PropBoard from '@/components/prop-board'
 
 // ====================================================================== Export
 export default {
@@ -44,7 +51,8 @@ export default {
   layout: 'spaze',
 
   components: {
-    Thingie
+    Thingie,
+    PropBoard
   },
 
   async fetch ({ app, store }) {
@@ -54,7 +62,10 @@ export default {
   data () {
     return {
       socket: false,
-      editor: { open: false }
+      editor: {
+        x: 0,
+        y: 0
+      }
     }
   },
 
@@ -114,17 +125,18 @@ export default {
       }
     },
     openEditor (evt) {
-      this.editor = {
-        open: true,
-        left: evt.clientX,
-        top: evt.clientY
+      if (this.authenticated) {
+        this.editor = {
+          x: evt.clientX,
+          y: evt.clientY
+        }
+        this.$refs.propboard.openEditor()
       }
     },
     closeEditor (evt) {
-      console.log(evt)
-      if (this.editor.open && !evt.altKey) {
-        this.editor = {
-          open: false
+      if (this.authenticated) {
+        if (!evt.altKey) {
+          this.$refs.propboard.closeEditor()
         }
       }
     }
@@ -141,14 +153,4 @@ export default {
   overflow: scroll;
   z-index: 1;
 }
-
-.editor {
-  position: absolute;
-  border: 1px solid black;
-  visibility: hidden;
-  &.open {
-    visibility: visible;
-  }
-}
-
 </style>

--- a/packages/fe/store/collections.js
+++ b/packages/fe/store/collections.js
@@ -31,13 +31,17 @@ const actions = {
   async postCreateThingie ({ dispatch, rootGetters }, payload) {
     try {
       const token = rootGetters['pocket/pocket']
-      const response = await this.$axiosAuth.post('/post-create-thingie', {
+      const data = {
         file_id: payload.uploadedFileId,
         location: payload.location,
         creator_token: token,
         thingie_type: payload.type,
         text: payload.text
-      })
+      }
+      if (payload.at) {
+        data.at = payload.at
+      }
+      const response = await this.$axiosAuth.post('/post-create-thingie', data)
       return response.data.payload
     } catch (e) {
       console.log('================== [Store Action: modify/postCreateThingie]')

--- a/packages/fe/store/collections.js
+++ b/packages/fe/store/collections.js
@@ -28,10 +28,15 @@ const actions = {
     commit('ADD_THINGIE', thingie)
   },
   // ///////////////////////////////////////////////////////// postCreateThingie
-  async postCreateThingie ({ dispatch }, payload) {
+  async postCreateThingie ({ dispatch, rootGetters }, payload) {
     try {
+      const token = rootGetters['pocket/pocket']
       const response = await this.$axiosAuth.post('/post-create-thingie', {
-        file_id: payload.uploadedFileId
+        file_id: payload.uploadedFileId,
+        location: payload.location,
+        creator_token: token,
+        thingie_type: payload.type,
+        text: payload.text
       })
       return response.data.payload
     } catch (e) {

--- a/packages/fe/store/general.js
+++ b/packages/fe/store/general.js
@@ -1,11 +1,13 @@
 // ///////////////////////////////////////////////////////// Imports & Variables
 // -----------------------------------------------------------------------------
 import CloneDeep from 'lodash/cloneDeep'
+import LandingData from '@/data/landing.json'
 
 // /////////////////////////////////////////////////////////////////////// State
 // -----------------------------------------------------------------------------
 const state = () => ({
-  authenticated: false,
+  landing: {},
+  authenticated: true,
   clipboard: false,
   filterValue: '',
   loaders: []
@@ -14,6 +16,7 @@ const state = () => ({
 // ///////////////////////////////////////////////////////////////////// Getters
 // -----------------------------------------------------------------------------
 const getters = {
+  landing: state => state.landing,
   authenticated: state => state.authenticated,
   clipboard: state => state.clipboard,
   filterValue: state => state.filterValue,
@@ -23,6 +26,9 @@ const getters = {
 // ///////////////////////////////////////////////////////////////////// Actions
 // -----------------------------------------------------------------------------
 const actions = {
+  async setLandingData ({ commit }) {
+    commit('SET_LANDING_DATA', { key: 'data', data: LandingData })
+  },
   // ////////////////////////////////////////////////////////////// setClipboard
   setClipboard ({ commit }, text) {
     this.$addTextToClipboard(text)
@@ -74,8 +80,8 @@ const actions = {
 // /////////////////////////////////////////////////////////////////// Mutations
 // -----------------------------------------------------------------------------
 const mutations = {
-  SET_SITE_CONTENT (state, payload) {
-    state.siteContent[payload.key] = payload.data
+  SET_LANDING_DATA (state, payload) {
+    state.landing[payload.key] = payload.data
   },
   SET_STATIC_FILE (state, staticFiles) {
     state.staticFiles = staticFiles

--- a/packages/fe/store/general.js
+++ b/packages/fe/store/general.js
@@ -5,7 +5,7 @@ import CloneDeep from 'lodash/cloneDeep'
 // /////////////////////////////////////////////////////////////////////// State
 // -----------------------------------------------------------------------------
 const state = () => ({
-  authenticated: false,
+  authenticated: true,
   clipboard: false,
   filterValue: '',
   loaders: []

--- a/packages/fe/store/general.js
+++ b/packages/fe/store/general.js
@@ -5,7 +5,7 @@ import CloneDeep from 'lodash/cloneDeep'
 // /////////////////////////////////////////////////////////////////////// State
 // -----------------------------------------------------------------------------
 const state = () => ({
-  authenticated: true,
+  authenticated: false,
   clipboard: false,
   filterValue: '',
   loaders: []
@@ -48,7 +48,7 @@ const actions = {
     }
   },
   // ////////////////////////////////////////////////////////////// authenticate
-  async authenticate ({ commit, getters }, token) {
+  async authenticate ({ commit, getters, dispatch }, token) {
     try {
       const response = await this.$axiosAuth.get('/authenticate', {
         params: { token }
@@ -59,6 +59,9 @@ const actions = {
         category: authenticated ? 'success' : 'error',
         message: response.data.message
       })
+      if (authenticated) {
+        dispatch('pocket/setPocketToken', token, { root: true })
+      }
       commit('SET_AUTHENTICATION_STATUS', authenticated)
     } catch (e) {
       console.log('====================== [Store Action: general/authenticate]')

--- a/packages/fe/store/general.js
+++ b/packages/fe/store/general.js
@@ -7,7 +7,7 @@ import LandingData from '@/data/landing.json'
 // -----------------------------------------------------------------------------
 const state = () => ({
   landing: {},
-  authenticated: true,
+  authenticated: false,
   clipboard: false,
   filterValue: '',
   loaders: []


### PR DESCRIPTION
Changes in this PR:

- the thingie component is no longer renderless. It now has a wrapper div component with a slot and all event handler directives attached to it so as not to have to pass up methods to the parent. This doesn't change any functionality but makes the code much easier to follow. Communication with the server via socket is still handled by the parent page component.

- thingies can now be resized and rotated by using two fingers on the track pad while hovering over them

- a new type of thingie has been added - text thingies can be created by clicking on white space anywhere while holding option and a text area + submit field will pop up allowing text to be created and manipulated like the image thingies. Font family and font size can also be changed afterwards by editing the thingie.