### PR TITLE
fix: sound thingie page navigation

### DIFF
--- a/packages/fe/components/thingies/sound-thingie.vue
+++ b/packages/fe/components/thingies/sound-thingie.vue
@@ -183,6 +183,12 @@ export default {
     }
   },
 
+  mounted () {
+    if (this.audioContext) {
+      this.initSoundThingie()
+    }
+  },
+
   beforeDestroy () {
     if (this.player) { this.player.pause() }
     if (this.mousemove) { window.removeEventListener('mousemove', this.mousemove) }


### PR DESCRIPTION
Init sound thingie in mounted hook even when audioContext is already created.