### PR TITLE
feat: uploader image compression

### DIFF
--- a/packages/fe/modules/pocket/components/single-file-uploader.vue
+++ b/packages/fe/modules/pocket/components/single-file-uploader.vue
@@ -2,6 +2,7 @@
   <UploadInput
     :prompt-to-upload="true"
     accepted-mimetypes="image/jpeg,image/png,audio/wav,audio/mpeg,audio/x-m4a"
+    :max-file-size-mb="maxFileSizeMB"
     class="single-file-uploader"
     @statusChanged="statusChanged"
     @fileSelected="fileSelected"
@@ -64,11 +65,14 @@
 
     <template #prompt-to-upload="{ uploadFile, clearFileInput }">
 
-      <div class="upload-prompt">
-        {{ finalizeUploadPrompt }}
+      <div
+        class="upload-prompt"
+        v-html="finalizeUploadPrompt">
       </div>
 
-      <Bichos @path-complete="(coords) => { initUpload(coords, uploadFile) }" />
+      <Bichos
+        v-if="filesize < (maxFileSizeMB * 1000000)"
+        @path-complete="(coords) => { initUpload(coords, uploadFile) }" />
 
       <Button
         text="cancel"
@@ -130,6 +134,11 @@ export default {
       type: String,
       required: false,
       default: ''
+    },
+    maxFileSizeMB: {
+      type: Number,
+      required: false,
+      default: 8
     }
   },
 
@@ -146,10 +155,13 @@ export default {
     initializeUploadPrompt () {
       return this.initPrompt ? this.initPrompt : 'Upload a file'
     },
+    filesize () {
+      return this.file ? this.file.size : 0
+    },
     finalizeUploadPrompt () {
       if (this.file) {
-        return this.file.size > 5000000 ?
-          ":-O woaahh that's a big file !" :
+        return this.file.size > (this.maxFileSizeMB * 1000000) ?
+          `compressed file size is too big! :-O<br>max is ${this.maxFileSizeMB}mb` :
           this.finalPrompt ?
             this.finalPrompt :
             'Draw a shape to upload selected file'

--- a/packages/fe/modules/pocket/components/single-file-uploader.vue
+++ b/packages/fe/modules/pocket/components/single-file-uploader.vue
@@ -4,6 +4,7 @@
     accepted-mimetypes="image/jpeg,image/png,audio/wav,audio/mpeg,audio/x-m4a"
     class="single-file-uploader"
     @statusChanged="statusChanged"
+    @fileSelected="fileSelected"
     @fileChanged="fileChanged">
 
     <template #metadata="{ filename, filesize, mimetype }">
@@ -45,17 +46,20 @@
 
     <template #file-upload-button="{ clickFileInput }">
       <Button
-        v-if="!file && status !== 'upload-complete'"
+        v-if="!file && status !== 'upload-complete' && !processingFile"
         :text="initializeUploadPrompt"
         class="select-file-button uploader-button"
         type="A"
         @clicked="clickFileInput" />
       <Button
-        v-if="status === 'upload-finalized'"
+        v-if="status === 'upload-finalized' && !processingFile"
         text="Upload another file"
         class="upload-another-file-button uploader-button"
         type="A"
         @clicked="clickFileInput" />
+      <LoaderTripleDot
+        v-if="processingFile"
+        class="file-processing-loader theme-dark" />
     </template>
 
     <template #prompt-to-upload="{ uploadFile, clearFileInput }">
@@ -86,6 +90,7 @@ import Filesize from 'filesize'
 
 import UploadInput from '@/modules/uploader/components/upload-input'
 import Button from '@/components/button'
+import LoaderTripleDot from '@/components/spinners/triple-dot'
 import Tag from '@/components/tag'
 import Spinner from '@/components/spinners/material-circle'
 import IconCheckmark from '@/components/icons/checkmark'
@@ -98,6 +103,7 @@ export default {
   components: {
     UploadInput,
     Button,
+    LoaderTripleDot,
     Tag,
     Spinner,
     IconCheckmark,
@@ -131,7 +137,8 @@ export default {
     return {
       status: false,
       file: false,
-      pathData: []
+      pathData: [],
+      processingFile: false
     }
   },
 
@@ -179,7 +186,12 @@ export default {
     statusChanged (status) {
       this.status = status
     },
+    fileSelected () {
+      console.log('hit')
+      this.processingFile = true
+    },
     fileChanged (file) {
+      this.processingFile = false
       this.file = file
     },
     async finalizeUpload () {
@@ -338,5 +350,13 @@ export default {
   text-align: center;
   margin: 0.375rem 0;
   white-space: nowrap;
+}
+
+.file-processing-loader {
+  position: relative;
+  padding: 0.875rem 1rem;
+  // width: 100%;
+  // height: 100%;
+  opacity: 1;
 }
 </style>

--- a/packages/fe/modules/pocket/components/single-file-uploader.vue
+++ b/packages/fe/modules/pocket/components/single-file-uploader.vue
@@ -1,7 +1,7 @@
 <template>
   <UploadInput
     :prompt-to-upload="true"
-    accepted-mimetypes="image/jpeg,image/png,audio/wav,audio/mpeg,audio/x-m4a"
+    accepted-mimetypes="image/jpeg,image/png,audio/mpeg,audio/x-m4a"
     :max-file-size-mb="maxFileSizeMB"
     class="single-file-uploader"
     @statusChanged="statusChanged"
@@ -199,7 +199,6 @@ export default {
       this.status = status
     },
     fileSelected () {
-      console.log('hit')
       this.processingFile = true
     },
     fileChanged (file) {
@@ -207,7 +206,7 @@ export default {
       this.file = file
     },
     async finalizeUpload () {
-      const thingietype = ['audio/mpeg', 'audio/wav', 'audio/x-m4a'].includes(this.file.type) ? 'sound' : 'image'
+      const thingietype = ['audio/mpeg', 'audio/x-m4a'].includes(this.file.type) ? 'sound' : 'image'
       const complete = await this.postCreateThingie({
         uploadedFileId: this.file.id,
         location: this.destination,

--- a/packages/fe/modules/uploader/components/upload-input.vue
+++ b/packages/fe/modules/uploader/components/upload-input.vue
@@ -68,13 +68,12 @@ const getImageData = async (instance, file) => {
   }
 }
 
-const compressImage = async (file, useWebWorker) => {
+const compressImage = async (file, useWebWorker, maxSizeMB) => {
   ImageCompression.getExifOrientation(file).then((o) => {
     console.log("ExifOrientation", o)
   })
   const controller = typeof AbortController !== 'undefined' && new AbortController()
-  const maxSizeMB = 5
-  const maxWidthOrHeight = 2048
+  const maxWidthOrHeight = 3072
   const onProgress = (p) => {
     console.log("onProgress", p)
   }
@@ -124,6 +123,11 @@ export default {
       type: Boolean,
       required: false,
       default: false
+    },
+    maxFileSizeMB: {
+      type: Number,
+      required: false,
+      default: 8
     }
   },
 
@@ -186,7 +190,7 @@ export default {
         this.$emit('fileSelected')
         if (['image/jpeg', 'image/png'].includes(file.type)) {
           await getImageData(this, file)
-          const compressedImageFile = await compressImage(file, true)
+          const compressedImageFile = await compressImage(file, true, this.maxFileSizeMB)
           this.file = compressedImageFile
         } else {
           this.file = file

--- a/packages/fe/modules/uploader/components/upload-input.vue
+++ b/packages/fe/modules/uploader/components/upload-input.vue
@@ -50,11 +50,12 @@
 import { mapGetters } from 'vuex'
 
 import ColorThief from 'colorthief'
+import ImageCompression from 'browser-image-compression'
 
 // =================================================================== Functions
-const getImageData = (instance) => {
+const getImageData = async (instance, file) => {
   const reader = new FileReader()
-  reader.readAsDataURL(instance.file)
+  reader.readAsDataURL(file)
   reader.onload = (e) => {
     const image = new Image()
     const colorThief = new ColorThief()
@@ -65,6 +66,39 @@ const getImageData = (instance) => {
       instance.imageColorPalette = palette
     }
   }
+}
+
+const compressImage = async (file, useWebWorker) => {
+  ImageCompression.getExifOrientation(file).then((o) => {
+    console.log("ExifOrientation", o)
+  })
+  const controller = typeof AbortController !== 'undefined' && new AbortController()
+  const maxSizeMB = 5
+  const maxWidthOrHeight = 2048
+  const onProgress = (p) => {
+    console.log("onProgress", p)
+  }
+  const options = {
+    maxSizeMB,
+    maxWidthOrHeight,
+    useWebWorker,
+    onProgress
+  }
+  console.log(controller)
+  if (controller) {
+    options.signal = controller.signal
+  }
+  const compressedFile = await ImageCompression (file, options)
+    .then((output) => {
+      console.log("original", file)
+      console.log("output", output)
+      return output
+    })
+    .catch((error) => {
+      console.log(error.message)
+    })
+
+  return compressedFile
 }
 
 // ====================================================================== Export
@@ -143,20 +177,19 @@ export default {
       this.socket.on('module|file-upload-chunk|payload', this.uploadNextChunk)
       this.socket.on('module|file-upload-complete|payload', this.fileUploadComplete)
     })
-    // this.socket.on('disconnect', () => {
-    //   this.error = true
-    //   this.resetVideoUpload()
-    // })
   },
 
   methods: {
-    handleInputChange (e) {
+    async handleInputChange (e) {
       const file = e.target.files[0]
       if (file) {
-        this.file = file
         this.$emit('fileSelected')
-        if (['image/jpeg', 'image/png'].includes(this.file.type)) {
-          getImageData(this)
+        if (['image/jpeg', 'image/png'].includes(file.type)) {
+          await getImageData(this, file)
+          const compressedImageFile = await compressImage(file, true)
+          this.file = compressedImageFile
+        } else {
+          this.file = file
         }
         if (!this.promptToUpload) {
           this.uploadFile()

--- a/packages/fe/package-lock.json
+++ b/packages/fe/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@nuxtjs/axios": "^5.13.6",
         "@nuxtjs/style-resources": "^1.2.1",
+        "browser-image-compression": "^2.0.0",
         "colorthief": "npm:@pioug/colorthief@^3.0.1",
         "filesize": "^8.0.7",
         "glsl-shader-loader": "^0.1.6",
@@ -4302,6 +4303,14 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
+    },
+    "node_modules/browser-image-compression": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.0.tgz",
+      "integrity": "sha512-kBlkZo13yOOfcmrPW0M0K/UdZPogIQj2gRvXIM3FktAnfW6VRq9aY2RI+F6O0x6DMj1Xm+WLGgWcFK8Fu/ddnw==",
+      "dependencies": {
+        "uzip": "0.20201231.0"
+      }
     },
     "node_modules/browserify-aes": {
       "version": "1.2.0",
@@ -13501,6 +13510,11 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/uzip": {
+      "version": "0.20201231.0",
+      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
+      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng=="
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -18167,6 +18181,14 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
+    },
+    "browser-image-compression": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.0.tgz",
+      "integrity": "sha512-kBlkZo13yOOfcmrPW0M0K/UdZPogIQj2gRvXIM3FktAnfW6VRq9aY2RI+F6O0x6DMj1Xm+WLGgWcFK8Fu/ddnw==",
+      "requires": {
+        "uzip": "0.20201231.0"
+      }
     },
     "browserify-aes": {
       "version": "1.2.0",
@@ -25300,6 +25322,11 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+    },
+    "uzip": {
+      "version": "0.20201231.0",
+      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
+      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng=="
     },
     "vary": {
       "version": "1.1.2",

--- a/packages/fe/package.json
+++ b/packages/fe/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@nuxtjs/axios": "^5.13.6",
     "@nuxtjs/style-resources": "^1.2.1",
+    "browser-image-compression": "^2.0.0",
     "colorthief": "npm:@pioug/colorthief@^3.0.1",
     "filesize": "^8.0.7",
     "glsl-shader-loader": "^0.1.6",


### PR DESCRIPTION
Images are compressed client side using the browser-image-compression npm dependency before uploading to the server. In most cases this reduces file sizes by ~70%. WAVs have also been removed from the list of accepted audio formats as they are often too large/hi-fidelity. 