### PR TITLE
feat: fetch spaze thingies

### DIFF
--- a/packages/be/modules/thingie/rest/get-thingies.js
+++ b/packages/be/modules/thingie/rest/get-thingies.js
@@ -10,7 +10,10 @@ const MC = require('@Root/config')
 // -----------------------------------------------------------------------------
 MC.app.get('/get-thingies', async (req, res) => {
   try {
-    const thingies = await MC.model.Thingie.find({}).populate({
+    const locations = req.query.locations
+    const thingies = await MC.model.Thingie.find({
+      location: locations
+    }).populate({
       path: 'file_ref',
       select: 'filename file_ext aspect'
     })

--- a/packages/fe/pages/_id.vue
+++ b/packages/fe/pages/_id.vue
@@ -75,10 +75,10 @@ export default {
     Button
   },
 
-  async fetch ({ app, store }) {
+  async fetch ({ app, store, route }) {
     await store.dispatch('general/setLandingData')
     await store.dispatch('collections/getSpazes')
-    await store.dispatch('collections/getThingies')
+    await store.dispatch('collections/getThingies', { spazename: route.params.id })
   },
 
   data () {

--- a/packages/fe/pages/compost.vue
+++ b/packages/fe/pages/compost.vue
@@ -44,7 +44,7 @@ export default {
   async fetch ({ app, store }) {
     await store.dispatch('general/setLandingData')
     await store.dispatch('collections/getSpazes')
-    await store.dispatch('collections/getThingies')
+    await store.dispatch('collections/getThingies', { spazename: 'compost' })
   },
 
   head () {

--- a/packages/fe/store/collections.js
+++ b/packages/fe/store/collections.js
@@ -113,9 +113,13 @@ const actions = {
     }
   },
   // /////////////////////////////////////////////////////////////// getThingies
-  async getThingies ({ commit, getters }) {
+  async getThingies ({ commit, getters }, data) {
     try {
-      const response = await this.$axiosAuth.get('/get-thingies')
+      const response = await this.$axiosAuth.get('/get-thingies', {
+        params: {
+          locations: ['pocket', data.spazename]
+        }
+      })
       commit('ADD_THINGIES', response.data.payload)
     } catch (e) {
       console.log('=================== [Store Action: collections/getThingies]')


### PR DESCRIPTION
Retrieve only pocket thingies and thingies in the current spaze (current `_id` route or `compost`) from the `/get-thingies` endpoint.