### PR TITLE
feat: adjust pocket width to percentage instead of vw units

### DIFF
--- a/packages/fe/components/icons/chevron.vue
+++ b/packages/fe/components/icons/chevron.vue
@@ -1,16 +1,25 @@
 <template>
-  <svg class="icon icon-chevron" viewBox="0 0 9 6" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <path 
+  <svg class="icon icon-chevron" viewBox="0 0 9 6" fill="none" xmlns="http://www.w3.org/2000/svg" :data-thingie-id="thingieId">
+    <path
       fill-rule="evenodd" 
       clip-rule="evenodd" 
       d="M8.75242 0.828032C9.08235 1.15799 9.08235 1.69297 8.75242 2.0229L4.77534 5.99998L0.798253 2.0229C0.468291 1.69297 0.468291 1.15799 0.798253 0.828032C1.12821 0.498078 1.66317 0.498078 1.99313 0.828032L4.77534 3.61024L7.55754 0.828032C7.88748 0.498078 8.42248 0.498078 8.75242 0.828032Z" 
-      fill="#000000" />
+      fill="#000000"
+      :data-thingie-id="thingieId" />
   </svg>
 </template>
 
 <script>
 // ====================================================================== Export
 export default {
-  name: 'ChevronIcon'
+  name: 'ChevronIcon',
+
+  props: {
+    thingieId: {
+      type: [Boolean, String],
+      required: false,
+      default: ''
+    }
+  }
 }
 </script>

--- a/packages/fe/components/pop-spz.vue
+++ b/packages/fe/components/pop-spz.vue
@@ -47,8 +47,8 @@
             ref="uploader"
             :upload-on-draw-bicho="false"
             :upload-to-spaze="newSpazeName"
-            init-prompt="Upload a file to the new spaze"
-            final-prompt="Draw a shape to create the new spaze"
+            :init-prompt="`Upload a file to create ${newSpazeName}`"
+            :final-prompt="`Draw a shape to create ${newSpazeName}`"
             @draw-bicho-complete="createNewSpazeFrom404"
             @upload-finalized="successfullyCreated" />
         </div>
@@ -82,7 +82,7 @@ export default {
       inputs: [
         {
           input: 'name',
-          label: 'new spaze name:',
+          label: 'new page name:',
           disabled: true,
           value: ''
         }

--- a/packages/fe/components/thingies/touch-editor.vue
+++ b/packages/fe/components/thingies/touch-editor.vue
@@ -276,7 +276,7 @@ export default {
     setDestinations () {
       const possibleLocations = [
         { location: 'compost', text: 'move to compost' },
-        { location: this.currentSpaze, text: 'move to spaze' },
+        { location: this.currentSpaze, text: `move to ${this.currentSpaze}` },
         { location: 'pocket', text: 'move to pocket' }
       ]
       this.destinations = possibleLocations.filter(item => item.location !== this.thingie.location)
@@ -364,6 +364,7 @@ export default {
         color: #000000;
         @include fontWeight_Bold;
         @include linkHover(#000000);
+        white-space: nowrap;
       }
     }
     &.pocket {

--- a/packages/fe/components/touchmode-toolbar.vue
+++ b/packages/fe/components/touchmode-toolbar.vue
@@ -23,8 +23,10 @@
                 { editorOpen }
               ]"
               @click="$emit('toggle-thingie-editor')">
-              <span class="text">edit</span>
-              <Chevron />
+              <span 
+                class="text"
+                :data-thingie-id="thingie._id">edit</span>
+              <Chevron :thingie-id="thingie._id" />
             </button>
 
             <button
@@ -162,8 +164,8 @@ export default {
       padding: 2rem 1rem;
       top: 0;
       left: 0;
-      width: 100vw;
-      height: calc(100vh - $touchmodeToolbarHeight - 0.5px);
+      width: 100%;
+      height: calc(100% - $touchmodeToolbarHeight - 0.5px);
       overflow: scroll;
       background-color: rgba(white, 0.0);
       visibility: hidden;

--- a/packages/fe/data/landing.json
+++ b/packages/fe/data/landing.json
@@ -64,7 +64,7 @@
     "tips": [
       "to upload a thingie, open the pocket and click upload",
       "to move a thingie, click and drag it",
-      "to drag and drop a thingie into your pocket, the compost or a spaze,<br>click and drag while holding shift (chrome, firefox), or holding command (safari)",
+      "to drag and drop a thingie into your pocket, the compost or a page,<br>click and drag while holding shift (chrome, firefox), or holding command (safari)",
       "br",
       "to get rid of a thingie, drag and drop it into the open compost",
       "to add a text thingie, hold option and click anywhere on the white space",

--- a/packages/fe/modules/pocket/components/pocket.vue
+++ b/packages/fe/modules/pocket/components/pocket.vue
@@ -194,15 +194,19 @@ $pocketHeight: 30rem;
     .pocket-container,
     .pocket,
     #pocket-shader {
-      width: 100vw;
-      height: 100vh;
+      width: 100%;
+      height: 100%;
       border-radius: 0;
     }
     #pocket-shader {
       :deep(.glCanvas) {
-        width: calc(100vw + 10rem);
-        height: calc(100vh + 10rem);
+        width: calc(100% + 10rem);
+        height: calc(100% + 10rem);
       }
+    }
+    :deep(.canvas-container) {
+      width: 100%;
+      height: 100%;
     }
   }
 }


### PR DESCRIPTION
Adjust pocket width to percentage instead of vw units. Remove instances of 'spaze' in front end text and replace with either page name or 'page'.