### PR TITLE
fix: empty thingie path data conditions

### DIFF
--- a/packages/fe/components/thingies/image-thingie.vue
+++ b/packages/fe/components/thingies/image-thingie.vue
@@ -90,7 +90,7 @@ export default {
       return false
     },
     svgPath () {
-      if (Array.isArray(this.points)) {
+      if (Array.isArray(this.points) && this.points.length) {
         const svgPath = this.$simplifySvgPath(this.points, { tolerance: 0.001 })
         return svgPath + ' Z'
       }

--- a/packages/fe/components/thingies/sound-thingie.vue
+++ b/packages/fe/components/thingies/sound-thingie.vue
@@ -39,7 +39,7 @@
     </audio>
 
     <svg
-      v-if="path"
+      v-if="processedPathData"
       class="svg"
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 200 200">
@@ -156,8 +156,11 @@ export default {
       return points
     },
     processedPathData () {
-      const svgPath = this.$simplifySvgPath(this.points)
-      return svgPath
+      if (this.points.length) {
+        const svgPath = this.$simplifySvgPath(this.points)
+        return svgPath
+      }
+      return false
     },
     limitStrokeWidth () {
       if (this.strokeWidth < 1) { return -1 / (this.strokeWidth - 1) }


### PR DESCRIPTION
Check for empty path data on image and sound thingies before calling the 'simply svg path' function.