### PR TITLE
fix: production and stable socket urls missing forward slash

### DIFF
--- a/packages/fe/nuxt.config.js
+++ b/packages/fe/nuxt.config.js
@@ -110,8 +110,8 @@ export default {
         const env = process.env.SERVER_ENV
         let uri = 'https://localhost:3001/' // development
         switch (env) {
-          case 'stable': uri = 'https://stable.fuit.es'; break
-          case 'production': uri = 'https://fuit.es'; break
+          case 'stable': uri = 'https://stable.fuit.es/'; break
+          case 'production': uri = 'https://fuit.es/'; break
         } return uri
       }())
     }]

--- a/packages/music/nuxt.config.js
+++ b/packages/music/nuxt.config.js
@@ -110,8 +110,8 @@ export default {
         const env = process.env.SERVER_ENV
         let uri = 'https://localhost:3001/' // development
         switch (env) {
-          case 'stable': uri = 'https://stable.fuit.es'; break
-          case 'production': uri = 'https://fuit.es'; break
+          case 'stable': uri = 'https://stable.fuit.es/'; break
+          case 'production': uri = 'https://fuit.es/'; break
         } return uri
       }())
     }]


### PR DESCRIPTION
fix: production and stable socket urls missing forward slash before namespace