### PR TITLE
fix: missing instance namespace on portal image fetch req

### DIFF
--- a/packages/fe/components/portal.vue
+++ b/packages/fe/components/portal.vue
@@ -36,7 +36,7 @@ export default {
   },
 
   async fetch () {
-    const response = await this.$axiosAuth.get(`/get-page-background?page=${this.to.slug}`)
+    const response = await this.$axiosAuth.get(`/${this.$config.mongoInstance}/get-page-background?page=${this.to.slug}`)
     if (response.data.payload) {
       this.print = response.data.payload.data_url
     }

--- a/packages/music/components/portal.vue
+++ b/packages/music/components/portal.vue
@@ -36,7 +36,7 @@ export default {
   },
 
   async fetch () {
-    const response = await this.$axiosAuth.get(`/get-page-background?page=${this.to.slug}`)
+    const response = await this.$axiosAuth.get(`/${this.$config.mongoInstance}/get-page-background?page=${this.to.slug}`)
     if (response.data.payload) {
       this.print = response.data.payload.data_url
     }


### PR DESCRIPTION
fix: missing instance namespace on portal image fetch req