### PR TITLE
feat: interweave create portal

### DIFF
--- a/packages/be/modules/portal/model/index.js
+++ b/packages/be/modules/portal/model/index.js
@@ -46,6 +46,10 @@ const PortalSchema = new Schema({
   enabled: {
     type: Boolean,
     required: false
+  },
+  manual: {
+    type: Boolean,
+    required: false
   }
 }, {
   timestamps: true,

--- a/packages/be/modules/portal/rest/post-create-portal.js
+++ b/packages/be/modules/portal/rest/post-create-portal.js
@@ -1,0 +1,52 @@
+console.log('💡 [endpoint] /post-create-portal')
+
+// ///////////////////////////////////////////////////////////////////// Imports
+// -----------------------------------------------------------------------------
+const { SendData } = require('@Module_Utilities')
+
+const MC = require('@Root/config')
+
+// ///////////////////////////////////////////////////////////////////// Exports
+// -----------------------------------------------------------------------------
+const mongoInstances = Object.keys(MC.mongoInstances)
+for (let i = 0; i < mongoInstances.length; i++) {
+  const instance = mongoInstances[i]
+  MC.app.post(`/${instance}/post-create-portal`, async (req, res) => {
+    try {
+      const body = req.body
+      const edge = `${body.vertices[0].location}_${body.vertices[1].location}`
+      const vertices = {
+        a: body.vertices[0],
+        b: body.vertices[1]
+      }
+      const created = await MC.mongoInstances[instance].model.Portal.create({
+        thingie_ref: body.thingieId,
+        edge,
+        vertices,
+        enabled: true,
+        manual: true
+      })
+      for (let i = 0; i < body.vertices.length; i++) {
+        const updated = await MC.mongoInstances[instance].model.Page.findOneAndUpdate(
+          { name: body.vertices[i].location },
+          { $push: { portal_refs: created._id } },
+          { new: true }
+        ).populate({
+          path: 'portal_refs',
+          populate: { path: 'thingie_ref', select: 'colors' }
+        })
+        console.log(updated)
+        MC.socket.io
+          .of(`/${instance}`)
+          .to(`${instance}|pages`)
+          .emit('module|post-update-page|payload', updated)
+      }
+      console.log(`New portal opened between ${created.edge.replace('_', ' and ')}.`)
+      SendData(res, 200, 'Portal successfully created', created)
+    } catch (e) {
+      console.log(`============== [Endpoint: /${instance}/post-create-portal]`)
+      console.log(e)
+      SendData(res, 500, 'Something went wrong. Please try again.')
+    }
+  })
+}

--- a/packages/interweave/store/collections.js
+++ b/packages/interweave/store/collections.js
@@ -254,6 +254,24 @@ const actions = {
   // //////////////////////////////////////////////////////// clearEditorThingie
   clearEditorThingie ({ commit }) {
     commit('CLEAR_EDITOR_THINGIE')
+  },
+  // ////////////////////////////////////////////////////////// postCreatePortal
+  async postCreatePortal ({ dispatch }, payload) {
+    try {
+      const vertices = [
+        { location: payload.location, at: payload.at },
+        { location: payload.destination, at: payload.at }
+      ]
+      const response = await this.$axiosAuth.post(`/${this.app.$config.mongoInstance}/post-create-portal`, {
+        thingieId: payload.closestNeighbour,
+        vertices
+      })
+      const portal = response.data.payload
+      return portal
+    } catch (e) {
+      console.log('============== [Store Action: collections/postCreatePortal]')
+      console.log(e)
+    }
   }
 }
 


### PR DESCRIPTION
- new endpoint added to the be portal module: `/post-create-portal`
- interweave package updated with a new post method to create manually create new portals
- propboard component updated to be able to use this method to create new portals from a string input in the text area.
- the string should be the name of the destination page to connect the current page to