### PR TITLE
feat: draw thingie hit area

### DIFF
--- a/packages/fe/components/thingie/image.vue
+++ b/packages/fe/components/thingie/image.vue
@@ -130,7 +130,7 @@ const loadImage = () => {
 
 const drawImageThingieHitArea = useDebounceFn(() => {
   nextTick(() => {
-    if (imgNode.value) {
+    if (imgNode.value && !baseUrl.value.startsWith('https://localhost')) {
       imgNode.value.getNode().cache()
       imgNode.value.getNode().drawHitFromCache()
     }

--- a/packages/fe/components/thingie/image.vue
+++ b/packages/fe/components/thingie/image.vue
@@ -8,12 +8,17 @@
       <v-image :config="clipConfig" />
     </v-group>
     
-    <v-image :config="imageConfig" :key="key" />
+    <v-image
+      ref="imgNode"
+      :config="imageConfig" :key="key" />
 
   </v-group>
 </template>
 
 <script setup>
+// ====================================================================== Import
+import { useDebounceFn } from '@vueuse/core'
+
 // ======================================================================= Props
 const props = defineProps({
   fileRef: {
@@ -49,6 +54,7 @@ const canvas = ref(false)
 const clipPath = ref(false)
 const clipGroup = ref(null)
 const clipGroupVisible = ref(false)
+const imgNode = ref(null)
 const generalStore = useGeneralStore()
 const { baseUrl } = storeToRefs(generalStore)
 const key = ref(0)
@@ -75,7 +81,7 @@ const groupConfig = computed(() => ({
 
 // ==================================================================== Watchers
 watch(() => props.options, () => { key.value++ }, { deep: true })
-
+watch(() => imageConfig.value, () => { drawImageThingieHitArea() })
 watch(() => props.clipActive, (val) => {
   if (val && !canvas.value) {
     nextTick(() => { applyClipPath() })
@@ -117,6 +123,19 @@ const loadImage = () => {
   }
   img.src = `${baseUrl.value}/uploads/${props.fileRef._id}.${props.fileRef.file_ext}`
 }
+
+/**
+ * @method drawImageThingieHitArea 
+ */
+
+const drawImageThingieHitArea = useDebounceFn(() => {
+  nextTick(() => {
+    if (imgNode.value) {
+      imgNode.value.getNode().cache()
+      imgNode.value.getNode().drawHitFromCache()
+    }
+  })
+}, 100)
 
 // ======================================================================= Hooks
 onMounted(() => { loadImage() })

--- a/packages/fe/components/thingie/text.vue
+++ b/packages/fe/components/thingie/text.vue
@@ -86,12 +86,12 @@ const rasterizeText = () => {
     div.remove()
     emit('loaded', true)
     // draw hit area for raster
-    nextTick(() => {
-      if (imgNode.value) {
-        imgNode.value.getNode().cache()
-        imgNode.value.getNode().drawHitFromCache()
-      }
-    })
+    // nextTick(() => {
+    //   if (imgNode.value) {
+    //     imgNode.value.getNode().cache()
+    //     imgNode.value.getNode().drawHitFromCache()
+    //   }
+    // })
   })
 }
 </script>

--- a/packages/fe/components/thingie/text.vue
+++ b/packages/fe/components/thingie/text.vue
@@ -1,5 +1,9 @@
 <template>
-  <v-image v-if="raster" :config="textConfig" :key="key" />
+  <v-image
+    v-if="raster"
+    ref="imgNode"
+    :config="textConfig"
+    :key="key" />
 </template>
 
 <script setup>
@@ -33,6 +37,7 @@ const emit = defineEmits(['loaded'])
 // ======================================================================== Data
 const key = ref(0)
 const raster = ref(false)
+const imgNode = ref(null)
 
 // ==================================================================== Computed
 const textConfig = computed(() => ({
@@ -80,6 +85,13 @@ const rasterizeText = () => {
     key.value++
     div.remove()
     emit('loaded', true)
+    // draw hit area for raster
+    nextTick(() => {
+      if (imgNode.value) {
+        imgNode.value.getNode().cache()
+        imgNode.value.getNode().drawHitFromCache()
+      }
+    })
   })
 }
 </script>


### PR DESCRIPTION
Uses Konva `.cache()` and `.drawHitFromCache()` methods to create a selection area free of transparent pixels for image thingies. This feature has also been added to text thingies but is disabled as it makes them hard to select at small font sizes - solution for this to be worked out in a future PR. Lastly, this functionality is disabled in non-production environments because it throws tainted canvas CORS errors there.